### PR TITLE
helm: remove duplicate labels from default values

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -35,8 +35,7 @@ podAnnotations:
   kubectl.kubernetes.io/default-container: manager
 
 # Pod labels
-podLabels:
-  control-plane: controller-manager
+podLabels: {}
 
 # Pod security context
 podSecurityContext:
@@ -121,6 +120,4 @@ args:
   - --health-probe-bind-address=:8081
 
 # Labels to apply to all resources
-commonLabels:
-  app.kubernetes.io/name: headscale-operator
-  app.kubernetes.io/managed-by: helm
+commonLabels: {}


### PR DESCRIPTION
Fixes #32

The default `commonLabels` and `podLabels` in `values.yaml` duplicated keys already defined in `_helpers.tpl`:

- `app.kubernetes.io/name` (from `selectorLabels`)
- `app.kubernetes.io/managed-by` (from `.Release.Service`)
- `control-plane: controller-manager` (from `selectorLabels`)

This produces invalid YAML with duplicate mapping keys, which breaks strict YAML parsers (e.g. FluxCD HelmRelease with Kustomize post-renderer).

## Fix

Set `commonLabels: {}` and `podLabels: {}` as defaults. Users can still add custom labels via these values without conflict.

## Testing

Deployed via FluxCD HelmRelease on a Talos cluster. Confirmed no duplicate labels in rendered resources and no YAML parse errors.