### PR TITLE
docs: fix apikey naming in the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,11 +101,11 @@ spec:
     dns:
       magic_dns: false
   # Automatic API key management (optional)
-  apiKey:
-    autoManage: true        # Automatically create and rotate API keys
-    secretName: headscale-api-key
-    expiration: "2160h"     # API key expires in 90 days (2160 hours)
-    rotationBuffer: "240h"  # Rotate 10 days (240 hours) before expiration
+  api_key:
+    auto_manage: true  # Automatically create and rotate API keys
+    manager_image: headscale-api-key
+    expiration: "2160h"      # API key expires in 90 days (2160 hours)
+    rotation_buffer: "240h"   # Rotate 10 days (240 hours) before expiration
 ```
 
 Apply the configuration:

--- a/cmd/apikey-manager/README.md
+++ b/cmd/apikey-manager/README.md
@@ -51,12 +51,12 @@ metadata:
 spec:
   # ... other configuration ...
   
-  apiKey:
+  api_key:
     # Enable/disable automatic API key management (default: true)
-    autoManage: true
+    auto_manage: true
     
     # Name of the Kubernetes secret to store the API key (default: "headscale-api-key")
-    secretName: headscale-api-key
+    secret_name: headscale-api-key
     
     # API key expiration duration in Go duration format (default: "2160h")
     # Examples: "720h" (30 days), "2160h" (90 days), "8760h" (365 days)
@@ -67,7 +67,7 @@ spec:
     # Time before expiration to rotate the key (default: "1920h" = 80 days)
     # Must be less than expiration
     # Examples: "168h" (7 days), "240h" (10 days), "480h" (20 days)
-    rotationBuffer: "240h"
+    rotation_buffer: "240h"
 ```
 
 ## How It Works
@@ -182,14 +182,14 @@ kubectl auth can-i update secrets --as=system:serviceaccount:default:headscale
 
 ### Adding to an existing Headscale deployment
 
-The sidecar is automatically injected when `spec.apiKey.autoManage` is `true` (the default).
+The sidecar is automatically injected when `spec.api_key.auto_manage` is `true` (the default).
 
 To disable automatic API key management:
 
 ```yaml
 spec:
-  apiKey:
-    autoManage: false
+  api_key:
+    auto_manage: false
 ```
 
 ### Testing locally


### PR DESCRIPTION
Fixes: #67