### PR TITLE
feat: surface invalid ACL policy via PolicyValid status condition

### DIFF
--- a/internal/controller/headscale_controller.go
+++ b/internal/controller/headscale_controller.go
@@ -107,6 +107,16 @@ func (r *HeadscaleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return ctrl.Result{}, err
 	}
 
+	// Validate the inline ACL policy up-front so a malformed document surfaces
+	// on the Headscale CRD's status (and operator logs) rather than failing
+	// silently. Reconciliation continues either way: Headscale itself doesn't
+	// load Inline (the AutoApprover controller pushes it via gRPC), so a bad
+	// policy must not block the StatefulSet from coming up.
+	policyCond := validateACLPolicy(headscale)
+	if policyCond.Status == metav1.ConditionFalse {
+		log.Error(fmt.Errorf("%s", policyCond.Message), "Invalid acl_policy.inline")
+	}
+
 	// Reconcile RBAC resources only if APIKey.AutoManage is true or nil (default true)
 	if headscale.Spec.APIKey.AutoManage == nil || *headscale.Spec.APIKey.AutoManage {
 		// Reconcile ServiceAccount
@@ -153,12 +163,33 @@ func (r *HeadscaleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}
 
 	// Update status
-	if err := r.updateStatus(ctx, headscale); err != nil {
+	if err := r.updateStatus(ctx, headscale, policyCond); err != nil {
 		log.Error(err, "Failed to update Headscale status")
 		return ctrl.Result{}, err
 	}
 
 	return ctrl.Result{}, nil
+}
+
+// validateACLPolicy parses the inline ACL policy and returns a PolicyValid
+// status condition reflecting the result. An empty inline policy is treated as
+// valid so users always get explicit confirmation that the operator inspected
+// their config.
+func validateACLPolicy(headscale *headscalev1beta1.Headscale) metav1.Condition {
+	cond := metav1.Condition{
+		Type:               "PolicyValid",
+		ObservedGeneration: headscale.Generation,
+	}
+	if _, err := parseInlinePolicy(headscale.Spec.ACLPolicy.Inline); err != nil {
+		cond.Status = metav1.ConditionFalse
+		cond.Reason = "InvalidPolicy"
+		cond.Message = err.Error()
+		return cond
+	}
+	cond.Status = metav1.ConditionTrue
+	cond.Reason = "Valid"
+	cond.Message = "acl_policy.inline parsed successfully"
+	return cond
 }
 
 // handleDeletion handles the deletion of a Headscale instance
@@ -391,11 +422,17 @@ func (r *HeadscaleReconciler) reconcileRoleBinding(ctx context.Context, headscal
 	return nil
 }
 
-// updateStatus updates the status of the Headscale instance
-func (r *HeadscaleReconciler) updateStatus(ctx context.Context, headscale *headscalev1beta1.Headscale) error {
+// updateStatus updates the status of the Headscale instance. The caller passes
+// the already-computed PolicyValid condition so we don't re-parse the inline
+// policy here.
+func (r *HeadscaleReconciler) updateStatus(
+	ctx context.Context,
+	headscale *headscalev1beta1.Headscale,
+	policyCond metav1.Condition,
+) error {
 	patch := client.MergeFrom(headscale.DeepCopy())
 
-	desired := metav1.Condition{
+	ready := metav1.Condition{
 		Type:               "Ready",
 		Status:             metav1.ConditionTrue,
 		Reason:             "Reconciled",
@@ -403,7 +440,9 @@ func (r *HeadscaleReconciler) updateStatus(ctx context.Context, headscale *heads
 		ObservedGeneration: headscale.Generation,
 	}
 
-	if !meta.SetStatusCondition(&headscale.Status.Conditions, desired) {
+	changed := meta.SetStatusCondition(&headscale.Status.Conditions, ready)
+	changed = meta.SetStatusCondition(&headscale.Status.Conditions, policyCond) || changed
+	if !changed {
 		return nil
 	}
 

--- a/internal/controller/headscale_controller_test.go
+++ b/internal/controller/headscale_controller_test.go
@@ -54,7 +54,7 @@ var _ = Describe("Headscale Controller", func() {
 
 		AfterEach(func() {
 			By("Cleaning up all test resources with various suffixes")
-			suffixes := []string{"", "-automanage", "-no-automanage", "-update", "-deletion", "-replicas", "-pvc", "-security", "-extras"}
+			suffixes := []string{"", "-automanage", "-no-automanage", "-update", "-deletion", "-replicas", "-pvc", "-security", "-extras", "-bad-policy"}
 
 			for _, suffix := range suffixes {
 				crName := "test-headscale" + suffix
@@ -891,5 +891,99 @@ var _ = Describe("Headscale Controller", func() {
 			Expect(labels["app.kubernetes.io/instance"]).To(Equal("test-instance"))
 			Expect(labels["app.kubernetes.io/managed-by"]).To(Equal("headscale-operator"))
 		})
+
+		It("should surface a PolicyValid=False status condition when inline ACL policy is malformed", func() {
+			ctx := context.Background()
+			badPolicyName := types.NamespacedName{
+				Name:      "test-headscale-bad-policy",
+				Namespace: "default",
+			}
+
+			By("Creating the Headscale resource with an invalid inline policy")
+			headscale := &headscalev1beta1.Headscale{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      badPolicyName.Name,
+					Namespace: badPolicyName.Namespace,
+				},
+				Spec: headscalev1beta1.HeadscaleSpec{
+					Version:  "v0.28.0",
+					Replicas: 1,
+					Config: headscalev1beta1.HeadscaleConfig{
+						ServerURL:  "https://headscale.example.com",
+						ListenAddr: "0.0.0.0:8080",
+					},
+					ACLPolicy: headscalev1beta1.ACLPolicyConfig{
+						// Missing quotes around object keys — the exact failure mode from issue #75.
+						Inline: `{ acls: [ { action: "accept", src: ["*"], dst: ["*:*"] } ] }`,
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, headscale)).To(Succeed())
+			DeferCleanup(func() {
+				_ = k8sClient.Delete(ctx, headscale)
+			})
+
+			By("Reconciling the resource")
+			controllerReconciler := &HeadscaleReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: badPolicyName})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying PolicyValid condition is False with InvalidPolicy reason")
+			updated := &headscalev1beta1.Headscale{}
+			Eventually(func() bool {
+				if err := k8sClient.Get(ctx, badPolicyName, updated); err != nil {
+					return false
+				}
+				for _, c := range updated.Status.Conditions {
+					if c.Type == "PolicyValid" &&
+						c.Status == metav1.ConditionFalse &&
+						c.Reason == "InvalidPolicy" {
+						return true
+					}
+				}
+				return false
+			}, time.Second*10, time.Millisecond*250).Should(BeTrue())
+		})
+	})
+})
+
+var _ = Describe("validateACLPolicy", func() {
+	It("returns PolicyValid=True when inline is empty", func() {
+		h := &headscalev1beta1.Headscale{}
+		cond := validateACLPolicy(h)
+		Expect(cond.Type).To(Equal("PolicyValid"))
+		Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+		Expect(cond.Reason).To(Equal("Valid"))
+	})
+
+	It("returns PolicyValid=True for valid HuJSON", func() {
+		h := &headscalev1beta1.Headscale{
+			Spec: headscalev1beta1.HeadscaleSpec{
+				ACLPolicy: headscalev1beta1.ACLPolicyConfig{
+					Inline: `{
+						// trailing-comma-friendly HuJSON is acceptable
+						"acls": [{"action": "accept", "src": ["*"], "dst": ["*:*"]},],
+					}`,
+				},
+			},
+		}
+		Expect(validateACLPolicy(h).Status).To(Equal(metav1.ConditionTrue))
+	})
+
+	It("returns PolicyValid=False with InvalidPolicy reason for malformed inline", func() {
+		h := &headscalev1beta1.Headscale{
+			Spec: headscalev1beta1.HeadscaleSpec{
+				ACLPolicy: headscalev1beta1.ACLPolicyConfig{
+					Inline: `{ acls: not-a-policy }`,
+				},
+			},
+		}
+		cond := validateACLPolicy(h)
+		Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+		Expect(cond.Reason).To(Equal("InvalidPolicy"))
+		Expect(cond.Message).NotTo(BeEmpty())
 	})
 })

--- a/internal/controller/headscaleautoapprover_controller.go
+++ b/internal/controller/headscaleautoapprover_controller.go
@@ -390,24 +390,42 @@ const (
 	policyKeyExitNode      = "exitNode"
 )
 
+// parseInlinePolicy parses the inline HuJSON policy string into a policyDocument.
+// An empty input yields an empty document. Error wording is shared with the
+// HeadscaleReconciler, which surfaces it on the parent CRD's PolicyValid status
+// condition so users see the same diagnostics regardless of which controller
+// caught the parse failure.
+func parseInlinePolicy(inline string) (policyDocument, error) {
+	doc := policyDocument{}
+	if inline == "" {
+		return doc, nil
+	}
+	// Headscale's policy file is HuJSON (JSON with comments + trailing
+	// commas), so accept the same dialect on input. Standardize() rewrites
+	// it to strict JSON before unmarshaling.
+	standardized, err := hujson.Standardize([]byte(inline))
+	if err != nil {
+		return nil, fmt.Errorf("acl_policy.inline is not valid HuJSON: %w", err)
+	}
+	if err := json.Unmarshal(standardized, &doc); err != nil {
+		return nil, fmt.Errorf("acl_policy.inline failed to unmarshal: %w", err)
+	}
+	return doc, nil
+}
+
 // buildPolicyDocument merges the inline base, tag owners, and auto-approver
 // entries into a single JSON document ready for SetPolicy.
 func buildPolicyDocument(
 	base *headscalev1beta1.ACLPolicyConfig,
 	approvers []headscalev1beta1.HeadscaleAutoApprover,
 ) (string, error) {
-	doc := policyDocument{}
-	if base != nil && base.Inline != "" {
-		// Headscale's policy file is HuJSON (JSON with comments + trailing
-		// commas), so accept the same dialect on input. Standardize() rewrites
-		// it to strict JSON before unmarshaling.
-		standardized, err := hujson.Standardize([]byte(base.Inline))
-		if err != nil {
-			return "", fmt.Errorf("acl_policy.inline is not valid HuJSON: %w", err)
-		}
-		if err := json.Unmarshal(standardized, &doc); err != nil {
-			return "", fmt.Errorf("acl_policy.inline failed to unmarshal: %w", err)
-		}
+	inline := ""
+	if base != nil {
+		inline = base.Inline
+	}
+	doc, err := parseInlinePolicy(inline)
+	if err != nil {
+		return "", err
 	}
 
 	if base != nil && len(base.TagOwners) > 0 {


### PR DESCRIPTION
Parse acl_policy.inline in the Headscale reconciler and report the result on a PolicyValid condition so a malformed HuJSON document no longer fails silently. Reconciliation continues regardless: the inline policy is consumed only by the AutoApprover controller's gRPC push, so blocking it would prevent unrelated spec edits from taking effect.

Closes: #75 