### PR TITLE
feat: allow PreAuthKey creation without user reference

### DIFF
--- a/api/v1beta1/headscalepreauthkey_types.go
+++ b/api/v1beta1/headscalepreauthkey_types.go
@@ -28,13 +28,15 @@ type HeadscalePreAuthKeySpec struct {
 	HeadscaleRef string `json:"headscaleRef"`
 
 	// HeadscaleUserRef is the name of the HeadscaleUser resource to create the preauth key for
-	// Either HeadscaleUserRef or UserID must be specified, but not both
+	// HeadscaleUserRef and UserID are mutually exclusive. If neither is set, the key is
+	// created without a user (a "tags-only" key) and Tags must be non-empty.
 	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`
 	// +optional
 	HeadscaleUserRef string `json:"headscaleUserRef,omitempty"`
 
 	// UserID is the ID of the user in Headscale to create the preauth key for
-	// Either HeadscaleUserRef or UserID must be specified, but not both
+	// HeadscaleUserRef and UserID are mutually exclusive. If neither is set, the key is
+	// created without a user (a "tags-only" key) and Tags must be non-empty.
 	// +kubebuilder:validation:Minimum=1
 	// +optional
 	UserID uint64 `json:"userId,omitempty"`
@@ -86,10 +88,12 @@ type HeadscalePreAuthKeyStatus struct {
 // +kubebuilder:resource:shortName=hspak;hspre
 // +kubebuilder:printcolumn:name="HeadscaleUser",type=string,JSONPath=`.spec.headscaleUserRef`
 // +kubebuilder:printcolumn:name="UserID",type=integer,JSONPath=`.spec.userId`
+// +kubebuilder:printcolumn:name="Tags",type=string,JSONPath=`.spec.tags`
 // +kubebuilder:printcolumn:name="Reusable",type=boolean,JSONPath=`.spec.reusable`
 // +kubebuilder:printcolumn:name="Ephemeral",type=boolean,JSONPath=`.spec.ephemeral`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
-// +kubebuilder:validation:XValidation:rule="(has(self.spec.headscaleUserRef) && self.spec.headscaleUserRef != \"\") != (has(self.spec.userId) && self.spec.userId != 0)",message="exactly one of spec.headscaleUserRef or spec.userId must be specified"
+// +kubebuilder:validation:XValidation:rule="!((has(self.spec.headscaleUserRef) && self.spec.headscaleUserRef != \"\") && (has(self.spec.userId) && self.spec.userId != 0))",message="spec.headscaleUserRef and spec.userId are mutually exclusive"
+// +kubebuilder:validation:XValidation:rule="(has(self.spec.headscaleUserRef) && self.spec.headscaleUserRef != \"\") || (has(self.spec.userId) && self.spec.userId != 0) || (has(self.spec.tags) && size(self.spec.tags) > 0)",message="spec.tags must be non-empty when neither spec.headscaleUserRef nor spec.userId is set"
 
 // HeadscalePreAuthKey is the Schema for the headscalepreauthkeys API
 type HeadscalePreAuthKey struct {

--- a/config/crd/bases/headscale.infrado.cloud_headscalepreauthkeys.yaml
+++ b/config/crd/bases/headscale.infrado.cloud_headscalepreauthkeys.yaml
@@ -24,6 +24,9 @@ spec:
     - jsonPath: .spec.userId
       name: UserID
       type: integer
+    - jsonPath: .spec.tags
+      name: Tags
+      type: string
     - jsonPath: .spec.reusable
       name: Reusable
       type: boolean
@@ -79,7 +82,8 @@ spec:
               headscaleUserRef:
                 description: |-
                   HeadscaleUserRef is the name of the HeadscaleUser resource to create the preauth key for
-                  Either HeadscaleUserRef or UserID must be specified, but not both
+                  HeadscaleUserRef and UserID are mutually exclusive. If neither is set, the key is
+                  created without a user (a "tags-only" key) and Tags must be non-empty.
                 pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                 type: string
               reusable:
@@ -102,7 +106,8 @@ spec:
               userId:
                 description: |-
                   UserID is the ID of the user in Headscale to create the preauth key for
-                  Either HeadscaleUserRef or UserID must be specified, but not both
+                  HeadscaleUserRef and UserID are mutually exclusive. If neither is set, the key is
+                  created without a user (a "tags-only" key) and Tags must be non-empty.
                 format: int64
                 minimum: 1
                 type: integer
@@ -181,9 +186,14 @@ spec:
         - spec
         type: object
         x-kubernetes-validations:
-        - message: exactly one of spec.headscaleUserRef or spec.userId must be specified
+        - message: spec.headscaleUserRef and spec.userId are mutually exclusive
+          rule: '!((has(self.spec.headscaleUserRef) && self.spec.headscaleUserRef
+            != "") && (has(self.spec.userId) && self.spec.userId != 0))'
+        - message: spec.tags must be non-empty when neither spec.headscaleUserRef
+            nor spec.userId is set
           rule: (has(self.spec.headscaleUserRef) && self.spec.headscaleUserRef !=
-            "") != (has(self.spec.userId) && self.spec.userId != 0)
+            "") || (has(self.spec.userId) && self.spec.userId != 0) || (has(self.spec.tags)
+            && size(self.spec.tags) > 0)
     served: true
     storage: true
     subresources:

--- a/config/samples/headscale_v1beta1_headscalepreauthkey.yaml
+++ b/config/samples/headscale_v1beta1_headscalepreauthkey.yaml
@@ -9,9 +9,11 @@ spec:
   # Reference to the Headscale instance
   headscaleRef: headscale-sample
   
-  # Reference to the HeadscaleUser (use either headscaleUserRef or userId)
+  # Reference to the HeadscaleUser (use either headscaleUserRef or userId).
+  # Both fields are optional and mutually exclusive: omit both to create a
+  # tags-only key (in which case `tags` below must be non-empty).
   headscaleUserRef: headscaleuser-sample
-  
+
   # Alternatively, you can specify the user ID directly:
   # userId: 1
   

--- a/internal/controller/headscalepreauthkey_controller.go
+++ b/internal/controller/headscalepreauthkey_controller.go
@@ -108,99 +108,10 @@ func (r *HeadscalePreAuthKeyReconciler) Reconcile(ctx context.Context, req ctrl.
 		return ctrl.Result{}, err
 	}
 
-	// Validate that either HeadscaleUserRef or UserID is provided
-	if preAuthKey.Spec.HeadscaleUserRef == "" && preAuthKey.Spec.UserID == 0 {
-		log.Error(nil, "Either HeadscaleUserRef or UserID must be specified")
-		if err := r.updateStatusCondition(ctx, preAuthKey, metav1.Condition{
-			Type:    "Ready",
-			Status:  metav1.ConditionFalse,
-			Reason:  "InvalidSpec",
-			Message: "Either HeadscaleUserRef or UserID must be specified",
-		}); err != nil {
-			return ctrl.Result{}, err
-		}
-		return ctrl.Result{}, nil
-	}
-
-	// Validate that both are not provided
-	if preAuthKey.Spec.HeadscaleUserRef != "" && preAuthKey.Spec.UserID != 0 {
-		log.Error(nil, "Only one of HeadscaleUserRef or UserID should be specified")
-		if err := r.updateStatusCondition(ctx, preAuthKey, metav1.Condition{
-			Type:    "Ready",
-			Status:  metav1.ConditionFalse,
-			Reason:  "InvalidSpec",
-			Message: "Only one of HeadscaleUserRef or UserID should be specified, not both",
-		}); err != nil {
-			return ctrl.Result{}, err
-		}
-		return ctrl.Result{}, nil
-	}
-
-	// Determine the user ID to use
-	var userID uint64
-	if preAuthKey.Spec.HeadscaleUserRef != "" {
-		// Get the referenced HeadscaleUser instance
-		headscaleUser := &headscalev1beta1.HeadscaleUser{}
-		err = r.Get(ctx, types.NamespacedName{
-			Name:      preAuthKey.Spec.HeadscaleUserRef,
-			Namespace: preAuthKey.Namespace,
-		}, headscaleUser)
-		if err != nil {
-			if apierrors.IsNotFound(err) {
-				log.Error(err, "Referenced HeadscaleUser not found", "HeadscaleUserRef", preAuthKey.Spec.HeadscaleUserRef)
-				if err := r.updateStatusCondition(ctx, preAuthKey, metav1.Condition{
-					Type:    "Ready",
-					Status:  metav1.ConditionFalse,
-					Reason:  "UserNotFound",
-					Message: fmt.Sprintf("Referenced HeadscaleUser %s not found", preAuthKey.Spec.HeadscaleUserRef),
-				}); err != nil {
-					return ctrl.Result{}, err
-				}
-				return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
-			}
-			log.Error(err, "Failed to get referenced HeadscaleUser")
-			return ctrl.Result{}, err
-		}
-
-		// Check if user has a UserID (is created in Headscale)
-		if headscaleUser.Status.UserID == "" {
-			log.Info("User not yet created in Headscale, waiting", "HeadscaleUserRef", preAuthKey.Spec.HeadscaleUserRef)
-			if err := r.updateStatusCondition(ctx, preAuthKey, metav1.Condition{
-				Type:    "Ready",
-				Status:  metav1.ConditionFalse,
-				Reason:  "UserNotReady",
-				Message: fmt.Sprintf("User %s not yet created in Headscale", preAuthKey.Spec.HeadscaleUserRef),
-			}); err != nil {
-				return ctrl.Result{}, err
-			}
-			return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
-		}
-
-		// Parse the user ID from HeadscaleUser status
-		parsedUserID, err := strconv.ParseUint(headscaleUser.Status.UserID, 10, 64)
-		if err != nil {
-			log.Error(err, "Failed to parse user ID from HeadscaleUser")
-			if err := r.updateStatusCondition(ctx, preAuthKey, metav1.Condition{
-				Type:    "Ready",
-				Status:  metav1.ConditionFalse,
-				Reason:  "InvalidUserID",
-				Message: fmt.Sprintf("Failed to parse user ID: %v", err),
-			}); err != nil {
-				return ctrl.Result{}, err
-			}
-			return ctrl.Result{}, fmt.Errorf("failed to parse user ID: %w", err)
-		}
-		userID = parsedUserID
-
-		// Set owner reference to HeadscaleUser for automatic cleanup
-		// This ensures when HeadscaleUser is deleted, the PreAuthKey is also deleted
-		if err := r.ensureHeadscaleUserOwnerReference(ctx, preAuthKey, headscaleUser); err != nil {
-			log.Error(err, "Failed to set owner reference to HeadscaleUser")
-			return ctrl.Result{}, err
-		}
-	} else {
-		// Use the directly provided UserID
-		userID = preAuthKey.Spec.UserID
+	// Resolve the userID to pass to Headscale. Zero means "no user" (tags-only key).
+	userID, result, done, err := r.resolveUserID(ctx, preAuthKey)
+	if done || err != nil {
+		return result, err
 	}
 
 	// Check if the preauth key already exists
@@ -241,12 +152,113 @@ func (r *HeadscalePreAuthKeyReconciler) Reconcile(ctx context.Context, req ctrl.
 		return ctrl.Result{}, err
 	}
 
-	userRefInfo := fmt.Sprintf("UserID: %d", userID)
-	if preAuthKey.Spec.HeadscaleUserRef != "" {
+	var userRefInfo string
+	switch {
+	case preAuthKey.Spec.HeadscaleUserRef != "":
 		userRefInfo = fmt.Sprintf("HeadscaleUserRef: %s", preAuthKey.Spec.HeadscaleUserRef)
+	case userID != 0:
+		userRefInfo = fmt.Sprintf("UserID: %d", userID)
+	default:
+		userRefInfo = "tags-only"
 	}
 	log.Info("Successfully created preauth key", "UserInfo", userRefInfo)
 	return ctrl.Result{}, nil
+}
+
+// resolveUserID validates the user reference fields on the spec and resolves
+// the Headscale user ID to use when creating the key. A returned userID of 0
+// means the key should be created without a user (tags-only). When done is
+// true, the caller should return immediately with the supplied result.
+func (r *HeadscalePreAuthKeyReconciler) resolveUserID(
+	ctx context.Context,
+	preAuthKey *headscalev1beta1.HeadscalePreAuthKey,
+) (userID uint64, result ctrl.Result, done bool, err error) {
+	log := logf.FromContext(ctx)
+
+	if preAuthKey.Spec.HeadscaleUserRef != "" && preAuthKey.Spec.UserID != 0 {
+		log.Error(nil, "Only one of HeadscaleUserRef or UserID should be specified")
+		if err := r.updateStatusCondition(ctx, preAuthKey, metav1.Condition{
+			Type:    "Ready",
+			Status:  metav1.ConditionFalse,
+			Reason:  "InvalidSpec",
+			Message: "Only one of HeadscaleUserRef or UserID should be specified, not both",
+		}); err != nil {
+			return 0, ctrl.Result{}, true, err
+		}
+		return 0, ctrl.Result{}, true, nil
+	}
+
+	if preAuthKey.Spec.HeadscaleUserRef == "" && preAuthKey.Spec.UserID == 0 && len(preAuthKey.Spec.Tags) == 0 {
+		log.Error(nil, "Tags must be set when neither HeadscaleUserRef nor UserID is specified")
+		if err := r.updateStatusCondition(ctx, preAuthKey, metav1.Condition{
+			Type:    "Ready",
+			Status:  metav1.ConditionFalse,
+			Reason:  "InvalidSpec",
+			Message: "Tags must be non-empty when neither HeadscaleUserRef nor UserID is specified",
+		}); err != nil {
+			return 0, ctrl.Result{}, true, err
+		}
+		return 0, ctrl.Result{}, true, nil
+	}
+
+	if preAuthKey.Spec.HeadscaleUserRef == "" {
+		return preAuthKey.Spec.UserID, ctrl.Result{}, false, nil
+	}
+
+	headscaleUser := &headscalev1beta1.HeadscaleUser{}
+	if err := r.Get(ctx, types.NamespacedName{
+		Name:      preAuthKey.Spec.HeadscaleUserRef,
+		Namespace: preAuthKey.Namespace,
+	}, headscaleUser); err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Error(err, "Referenced HeadscaleUser not found", "HeadscaleUserRef", preAuthKey.Spec.HeadscaleUserRef)
+			if err := r.updateStatusCondition(ctx, preAuthKey, metav1.Condition{
+				Type:    "Ready",
+				Status:  metav1.ConditionFalse,
+				Reason:  "UserNotFound",
+				Message: fmt.Sprintf("Referenced HeadscaleUser %s not found", preAuthKey.Spec.HeadscaleUserRef),
+			}); err != nil {
+				return 0, ctrl.Result{}, true, err
+			}
+			return 0, ctrl.Result{RequeueAfter: 30 * time.Second}, true, nil
+		}
+		log.Error(err, "Failed to get referenced HeadscaleUser")
+		return 0, ctrl.Result{}, true, err
+	}
+
+	if headscaleUser.Status.UserID == "" {
+		log.Info("User not yet created in Headscale, waiting", "HeadscaleUserRef", preAuthKey.Spec.HeadscaleUserRef)
+		if err := r.updateStatusCondition(ctx, preAuthKey, metav1.Condition{
+			Type:    "Ready",
+			Status:  metav1.ConditionFalse,
+			Reason:  "UserNotReady",
+			Message: fmt.Sprintf("User %s not yet created in Headscale", preAuthKey.Spec.HeadscaleUserRef),
+		}); err != nil {
+			return 0, ctrl.Result{}, true, err
+		}
+		return 0, ctrl.Result{RequeueAfter: 10 * time.Second}, true, nil
+	}
+
+	parsedUserID, err := strconv.ParseUint(headscaleUser.Status.UserID, 10, 64)
+	if err != nil {
+		log.Error(err, "Failed to parse user ID from HeadscaleUser")
+		if updateErr := r.updateStatusCondition(ctx, preAuthKey, metav1.Condition{
+			Type:    "Ready",
+			Status:  metav1.ConditionFalse,
+			Reason:  "InvalidUserID",
+			Message: fmt.Sprintf("Failed to parse user ID: %v", err),
+		}); updateErr != nil {
+			return 0, ctrl.Result{}, true, updateErr
+		}
+		return 0, ctrl.Result{}, true, fmt.Errorf("failed to parse user ID: %w", err)
+	}
+
+	if err := r.ensureHeadscaleUserOwnerReference(ctx, preAuthKey, headscaleUser); err != nil {
+		log.Error(err, "Failed to set owner reference to HeadscaleUser")
+		return 0, ctrl.Result{}, true, err
+	}
+
+	return parsedUserID, ctrl.Result{}, false, nil
 }
 
 // handleDeletion handles the deletion of a HeadscalePreAuthKey instance

--- a/internal/controller/headscalepreauthkey_controller_test.go
+++ b/internal/controller/headscalepreauthkey_controller_test.go
@@ -571,8 +571,8 @@ var _ = Describe("HeadscalePreAuthKey Controller", func() {
 			Expect(k8sClient.Delete(ctx, userLtt)).To(Succeed())
 		})
 
-		It("should reject spec with neither HeadscaleUserRef nor UserID", func() {
-			By("Attempting to create a HeadscalePreAuthKey without HeadscaleUserRef or UserID")
+		It("should reject spec with neither user reference nor tags", func() {
+			By("Attempting to create a HeadscalePreAuthKey without HeadscaleUserRef, UserID, or Tags")
 			preAuthKey := &headscalev1beta1.HeadscalePreAuthKey{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      resourceName + "-no-user",
@@ -587,7 +587,7 @@ var _ = Describe("HeadscalePreAuthKey Controller", func() {
 			By("Verifying that creation fails due to validation")
 			err := k8sClient.Create(ctx, preAuthKey)
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("exactly one of spec.headscaleUserRef or spec.userId must be specified"))
+			Expect(err.Error()).To(ContainSubstring("spec.tags must be non-empty when neither spec.headscaleUserRef nor spec.userId is set"))
 		})
 
 		It("should reject spec with both HeadscaleUserRef and UserID", func() {
@@ -608,7 +608,57 @@ var _ = Describe("HeadscalePreAuthKey Controller", func() {
 			By("Verifying that creation fails due to validation")
 			err := k8sClient.Create(ctx, preAuthKey)
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("exactly one of spec.headscaleUserRef or spec.userId must be specified"))
+			Expect(err.Error()).To(ContainSubstring("spec.headscaleUserRef and spec.userId are mutually exclusive"))
+		})
+
+		It("should accept and reconcile a tags-only HeadscalePreAuthKey (no user)", func() {
+			By("Creating a HeadscalePreAuthKey with tags but no user reference")
+			preAuthKey := &headscalev1beta1.HeadscalePreAuthKey{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      resourceName + "-tags-only",
+					Namespace: namespace,
+				},
+				Spec: headscalev1beta1.HeadscalePreAuthKeySpec{
+					HeadscaleRef: headscaleName,
+					Expiration:   "1h",
+					Tags:         []string{"tag:ci"},
+				},
+			}
+			Expect(k8sClient.Create(ctx, preAuthKey)).To(Succeed())
+
+			tagsOnlyNamespacedName := types.NamespacedName{
+				Name:      resourceName + "-tags-only",
+				Namespace: namespace,
+			}
+
+			By("Reconciling the created resource")
+			controllerReconciler := &HeadscalePreAuthKeyReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: tagsOnlyNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Checking that the finalizer was added")
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, tagsOnlyNamespacedName, preAuthKey)
+				if err != nil {
+					return false
+				}
+				return slices.Contains(preAuthKey.Finalizers, headscalePreAuthKeyFinalizer)
+			}, timeout, interval).Should(BeTrue())
+
+			By("Verifying no HeadscaleUser owner reference was set")
+			Expect(k8sClient.Get(ctx, tagsOnlyNamespacedName, preAuthKey)).To(Succeed())
+			for _, ref := range preAuthKey.GetOwnerReferences() {
+				Expect(ref.Kind).NotTo(Equal("HeadscaleUser"))
+			}
+
+			By("Cleaning up the test resource")
+			Expect(k8sClient.Delete(ctx, preAuthKey)).To(Succeed())
 		})
 
 		It("should handle deletion with finalizer", func() {


### PR DESCRIPTION
Headscale v0.28.0 (juanfont/headscale#2992) made the user field on CreatePreAuthKey optional, allowing tags-only keys whose identity comes from their tags. Relax the operator's CRD validation and controller checks to permit the same: headscaleUserRef and userId remain mutually exclusive but both are now optional, and tags must be non-empty when neither is set.

Closes: #84 