### PR TITLE
feat: allow PreAuthKey creation without expiration

### DIFF
--- a/api/v1beta1/headscalepreauthkey_types.go
+++ b/api/v1beta1/headscalepreauthkey_types.go
@@ -41,11 +41,11 @@ type HeadscalePreAuthKeySpec struct {
 	// +optional
 	UserID uint64 `json:"userId,omitempty"`
 
-	// Expiration is the duration after which the preauth key expires
-	// Examples: 30m, 24h, 1h30m, 300ms, 1.5h (must be a valid Go duration string)
-	// Valid time units are "s", "m", "h"
-	// +kubebuilder:validation:Pattern=`^([0-9]+(\.[0-9]+)?(s|m|h))+$`
-	// +kubebuilder:default="1h"
+	// Expiration is the duration after which the preauth key expires.
+	// Examples: 30m, 24h, 1h30m, 1.5h (must be a valid Go duration string).
+	// Valid time units are "s", "m", "h". Leave empty to create a key that
+	// never expires.
+	// +kubebuilder:validation:Pattern=`^$|^([0-9]+(\.[0-9]+)?(s|m|h))+$`
 	// +optional
 	Expiration string `json:"expiration,omitempty"`
 

--- a/config/crd/bases/headscale.infrado.cloud_headscalepreauthkeys.yaml
+++ b/config/crd/bases/headscale.infrado.cloud_headscalepreauthkeys.yaml
@@ -68,12 +68,12 @@ spec:
                   be ephemeral
                 type: boolean
               expiration:
-                default: 1h
                 description: |-
-                  Expiration is the duration after which the preauth key expires
-                  Examples: 30m, 24h, 1h30m, 300ms, 1.5h (must be a valid Go duration string)
-                  Valid time units are "s", "m", "h"
-                pattern: ^([0-9]+(\.[0-9]+)?(s|m|h))+$
+                  Expiration is the duration after which the preauth key expires.
+                  Examples: 30m, 24h, 1h30m, 1.5h (must be a valid Go duration string).
+                  Valid time units are "s", "m", "h". Leave empty to create a key that
+                  never expires.
+                pattern: ^$|^([0-9]+(\.[0-9]+)?(s|m|h))+$
                 type: string
               headscaleRef:
                 description: HeadscaleRef is the name of the Headscale instance to

--- a/internal/controller/headscalepreauthkey_controller.go
+++ b/internal/controller/headscalepreauthkey_controller.go
@@ -384,10 +384,14 @@ func (r *HeadscalePreAuthKeyReconciler) createPreAuthKey(
 ) error {
 	log := logf.FromContext(ctx)
 
-	// Parse expiration duration
-	expiration, err := time.ParseDuration(preAuthKey.Spec.Expiration)
-	if err != nil {
-		return fmt.Errorf("failed to parse expiration: %w", err)
+	// Parse expiration duration. An empty value means the key never expires.
+	var expiration time.Duration
+	if preAuthKey.Spec.Expiration != "" {
+		parsed, err := time.ParseDuration(preAuthKey.Spec.Expiration)
+		if err != nil {
+			return fmt.Errorf("failed to parse expiration: %w", err)
+		}
+		expiration = parsed
 	}
 
 	// Get the API key from the secret


### PR DESCRIPTION
Drop the implicit 1h default and accept an empty Expiration to create a non-expiring preauth key. The Headscale gRPC API treats a nil expiration timestamp as "never expires", which the client already honored when the duration is zero.

Closes: #87 