### PR TITLE
feat(HeadscalePreAuthKey): add headscaleNamespace for cross-namespace Headscale lookup

### DIFF
--- a/api/v1beta1/headscalepreauthkey_types.go
+++ b/api/v1beta1/headscalepreauthkey_types.go
@@ -11,6 +11,13 @@ type HeadscalePreAuthKeySpec struct {
 	// +required
 	HeadscaleRef string `json:"headscaleRef"`
 
+	// HeadscaleNamespace is the namespace of the referenced Headscale instance.
+	// If not set, defaults to the namespace of this HeadscalePreAuthKey resource,
+	// which allows a HeadscalePreAuthKey in one namespace to reference a Headscale
+	// instance in another (e.g. a shared networking namespace).
+	// +optional
+	HeadscaleNamespace string `json:"headscaleNamespace,omitempty"`
+
 	// HeadscaleUserRef is the name of the HeadscaleUser resource to create the preauth key for
 	// HeadscaleUserRef and UserID are mutually exclusive. If neither is set, the key is
 	// created without a user (a "tags-only" key) and Tags must be non-empty.

--- a/config/crd/bases/headscale.infrado.cloud_headscalepreauthkeys.yaml
+++ b/config/crd/bases/headscale.infrado.cloud_headscalepreauthkeys.yaml
@@ -75,6 +75,13 @@ spec:
                   never expires.
                 pattern: ^$|^([0-9]+(\.[0-9]+)?(s|m|h))+$
                 type: string
+              headscaleNamespace:
+                description: |-
+                  HeadscaleNamespace is the namespace of the referenced Headscale instance.
+                  If not set, defaults to the namespace of this HeadscalePreAuthKey resource,
+                  which allows a HeadscalePreAuthKey in one namespace to reference a Headscale
+                  instance in another (e.g. a shared networking namespace).
+                type: string
               headscaleRef:
                 description: HeadscaleRef is the name of the Headscale instance to
                   create the preauth key in

--- a/config/samples/headscale_v1beta1_headscalepreauthkey.yaml
+++ b/config/samples/headscale_v1beta1_headscalepreauthkey.yaml
@@ -8,7 +8,13 @@ metadata:
 spec:
   # Reference to the Headscale instance
   headscaleRef: headscale-sample
-  
+
+  # Optional: namespace of the Headscale instance. Defaults to the namespace of
+  # this resource. Set this when the Headscale CR lives in a different namespace
+  # (e.g. a shared networking namespace) so the secret is created co-located
+  # with the consumer.
+  # headscaleNamespace: networking
+
   # Reference to the HeadscaleUser (use either headscaleUserRef or userId).
   # Both fields are optional and mutually exclusive: omit both to create a
   # tags-only key (in which case `tags` below must be non-empty).

--- a/internal/controller/headscalepreauthkey_controller.go
+++ b/internal/controller/headscalepreauthkey_controller.go
@@ -70,19 +70,23 @@ func (r *HeadscalePreAuthKeyReconciler) Reconcile(ctx context.Context, req ctrl.
 	}
 
 	// Get the referenced Headscale instance
+	headscaleNS := preAuthKey.Namespace
+	if preAuthKey.Spec.HeadscaleNamespace != "" {
+		headscaleNS = preAuthKey.Spec.HeadscaleNamespace
+	}
 	headscale := &headscalev1beta1.Headscale{}
 	err = r.Get(ctx, types.NamespacedName{
 		Name:      preAuthKey.Spec.HeadscaleRef,
-		Namespace: preAuthKey.Namespace,
+		Namespace: headscaleNS,
 	}, headscale)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			log.Error(err, "Referenced Headscale instance not found", "HeadscaleRef", preAuthKey.Spec.HeadscaleRef)
+			log.Error(err, "Referenced Headscale instance not found", "HeadscaleRef", preAuthKey.Spec.HeadscaleRef, "HeadscaleNamespace", headscaleNS)
 			if err := r.updateStatusCondition(ctx, preAuthKey, metav1.Condition{
 				Type:    "Ready",
 				Status:  metav1.ConditionFalse,
 				Reason:  "HeadscaleNotFound",
-				Message: fmt.Sprintf("Referenced Headscale instance %s not found", preAuthKey.Spec.HeadscaleRef),
+				Message: fmt.Sprintf("Referenced Headscale instance %s not found in namespace %s", preAuthKey.Spec.HeadscaleRef, headscaleNS),
 			}); err != nil {
 				return ctrl.Result{}, err
 			}
@@ -254,15 +258,19 @@ func (r *HeadscalePreAuthKeyReconciler) handleDeletion(
 
 	if controllerutil.ContainsFinalizer(preAuthKey, headscalePreAuthKeyFinalizer) {
 		// Get the referenced Headscale instance
+		headscaleNS := preAuthKey.Namespace
+		if preAuthKey.Spec.HeadscaleNamespace != "" {
+			headscaleNS = preAuthKey.Spec.HeadscaleNamespace
+		}
 		headscale := &headscalev1beta1.Headscale{}
 		err := r.Get(ctx, types.NamespacedName{
 			Name:      preAuthKey.Spec.HeadscaleRef,
-			Namespace: preAuthKey.Namespace,
+			Namespace: headscaleNS,
 		}, headscale)
 		if err != nil {
 			if apierrors.IsNotFound(err) {
 				log.Info("Referenced Headscale instance not found during deletion, removing finalizer",
-					"HeadscaleRef", preAuthKey.Spec.HeadscaleRef)
+					"HeadscaleRef", preAuthKey.Spec.HeadscaleRef, "HeadscaleNamespace", headscaleNS)
 				controllerutil.RemoveFinalizer(preAuthKey, headscalePreAuthKeyFinalizer)
 				if err := r.Update(ctx, preAuthKey); err != nil {
 					return ctrl.Result{}, err

--- a/internal/controller/headscalepreauthkey_controller_test.go
+++ b/internal/controller/headscalepreauthkey_controller_test.go
@@ -334,6 +334,136 @@ var _ = Describe("HeadscalePreAuthKey Controller", func() {
 			Expect(k8sClient.Delete(ctx, preAuthKey)).To(Succeed())
 		})
 
+		It("should find Headscale CR in headscaleNamespace when set", func() {
+			const remoteNamespace = "headscale-remote-ns"
+
+			By("Creating the remote namespace")
+			ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: remoteNamespace}}
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: remoteNamespace}, &corev1.Namespace{})
+			if errors.IsNotFound(err) {
+				Expect(k8sClient.Create(ctx, ns)).To(Succeed())
+			}
+
+			By("Creating a Headscale CR in the remote namespace")
+			remoteHeadscale := &headscalev1beta1.Headscale{
+				ObjectMeta: metav1.ObjectMeta{Name: headscaleName, Namespace: remoteNamespace},
+				Spec: headscalev1beta1.HeadscaleSpec{
+					Version:  "v0.28.0",
+					Replicas: 1,
+					Config: headscalev1beta1.HeadscaleConfig{
+						ServerURL:         "https://headscale.example.com",
+						GRPCListenAddr:    "0.0.0.0:50443",
+						MetricsListenAddr: "0.0.0.0:9090",
+					},
+					PersistentVolumeClaim: headscalev1beta1.PersistentVolumeClaimConfig{
+						Size: resource.NewQuantity(128*1024*1024, resource.BinarySI),
+					},
+					APIKey: headscalev1beta1.APIKeyConfig{SecretName: "remote-api-key-secret"},
+				},
+			}
+			remoteHeadscaleNN := types.NamespacedName{Name: headscaleName, Namespace: remoteNamespace}
+			err = k8sClient.Get(ctx, remoteHeadscaleNN, &headscalev1beta1.Headscale{})
+			if errors.IsNotFound(err) {
+				Expect(k8sClient.Create(ctx, remoteHeadscale)).To(Succeed())
+			}
+
+			By("Creating the API key secret in the remote namespace")
+			remoteSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: "remote-api-key-secret", Namespace: remoteNamespace},
+				Data:       map[string][]byte{"api-key": []byte("remote-api-key-value")},
+			}
+			remoteSecretNN := types.NamespacedName{Name: "remote-api-key-secret", Namespace: remoteNamespace}
+			err = k8sClient.Get(ctx, remoteSecretNN, &corev1.Secret{})
+			if errors.IsNotFound(err) {
+				Expect(k8sClient.Create(ctx, remoteSecret)).To(Succeed())
+			}
+
+			By("Creating a HeadscalePreAuthKey in the local namespace with headscaleNamespace set")
+			crossNsKey := &headscalev1beta1.HeadscalePreAuthKey{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      resourceName + "-cross-ns",
+					Namespace: namespace,
+				},
+				Spec: headscalev1beta1.HeadscalePreAuthKeySpec{
+					HeadscaleRef:       headscaleName,
+					HeadscaleNamespace: remoteNamespace,
+					Tags:               []string{"tag:ci"},
+					Expiration:         "1h",
+				},
+			}
+			Expect(k8sClient.Create(ctx, crossNsKey)).To(Succeed())
+
+			crossNsNN := types.NamespacedName{Name: resourceName + "-cross-ns", Namespace: namespace}
+
+			By("Reconciling the resource")
+			controllerReconciler := &HeadscalePreAuthKeyReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: crossNsNN})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying the finalizer was added (Headscale CR was found across namespaces)")
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, crossNsNN, crossNsKey)
+				if err != nil {
+					return false
+				}
+				return slices.Contains(crossNsKey.Finalizers, headscalePreAuthKeyFinalizer)
+			}, timeout, interval).Should(BeTrue())
+
+			By("Cleaning up")
+			Expect(k8sClient.Delete(ctx, crossNsKey)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, remoteHeadscale)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, remoteSecret)).To(Succeed())
+		})
+
+		It("should set HeadscaleNotFound when Headscale CR is absent in headscaleNamespace", func() {
+			By("Creating a HeadscalePreAuthKey pointing to a non-existent namespace")
+			crossNsMissingKey := &headscalev1beta1.HeadscalePreAuthKey{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      resourceName + "-cross-ns-missing",
+					Namespace: namespace,
+				},
+				Spec: headscalev1beta1.HeadscalePreAuthKeySpec{
+					HeadscaleRef:       "non-existent-headscale",
+					HeadscaleNamespace: "does-not-exist",
+					Tags:               []string{"tag:ci"},
+					Expiration:         "1h",
+				},
+			}
+			Expect(k8sClient.Create(ctx, crossNsMissingKey)).To(Succeed())
+
+			crossNsMissingNN := types.NamespacedName{Name: resourceName + "-cross-ns-missing", Namespace: namespace}
+
+			By("Reconciling the resource")
+			controllerReconciler := &HeadscalePreAuthKeyReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: crossNsMissingNN})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying HeadscaleNotFound status is set")
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, crossNsMissingNN, crossNsMissingKey)
+				if err != nil {
+					return false
+				}
+				for _, condition := range crossNsMissingKey.Status.Conditions {
+					if condition.Type == readyConditionType &&
+						condition.Status == metav1.ConditionFalse &&
+						condition.Reason == headscaleNotFoundReason {
+						return true
+					}
+				}
+				return false
+			}, timeout, interval).Should(BeTrue())
+
+			By("Cleaning up")
+			Expect(k8sClient.Delete(ctx, crossNsMissingKey)).To(Succeed())
+		})
+
 		It("should handle missing HeadscaleUser reference", func() {
 			By("Creating a HeadscalePreAuthKey with non-existent HeadscaleUser reference")
 			preAuthKey := &headscalev1beta1.HeadscalePreAuthKey{


### PR DESCRIPTION
First of all, thanks for publishing this operator. I’m currently using it to build out a homelab using Tailscale and Pocket-ID, and it has been a great learning resource.

I am implementing a pattern where core infrastructure (Cert-Manager, Headscale, Pocket-ID) resides in a central infra namespace, while applications live in their own dedicated namespaces. This follows the pattern used by the Cert-Manager and Pocket-ID operators, where a resource in an application namespace references a central controller or instance in the infrastructure namespace.

Currently, the headscale-operator only watches its own namespace. I’ve expanded the scope to support cross-namespace lookups:

Cross-Namespace References: A HeadscalePreAuthKey in an application namespace can now reference a Headscale CR in a shared networking/infra namespace via a new headscaleNamespace field.

Backward Compatibility: If headscaleNamespace is unset, the behavior remains unchanged (the operator looks for the Headscale CR in the local namespace).

Secret Management: The generated Secret remains co-located with the HeadscalePreAuthKey. This ensures that ownerReference-based garbage collection works correctly within the application namespace.

Security Model: Access is governed by Kubernetes RBAC. Any namespace with permission to create HeadscalePreAuthKey resources can provision keys from the referenced Headscale instance. This aligns with the security models used by ClusterIssuer in Cert-Manager or PocketIDInstance in the Pocket-ID operator.

