### PR TITLE
fix: remove invalid bare manager_image from sample and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,6 @@ spec:
   # Automatic API key management (optional)
   api_key:
     auto_manage: true  # Automatically create and rotate API keys
-    manager_image: headscale-api-key
     expiration: "2160h"      # API key expires in 90 days (2160 hours)
     rotation_buffer: "240h"   # Rotate 10 days (240 hours) before expiration
 ```

--- a/config/samples/headscale_v1beta1_headscale.yaml
+++ b/config/samples/headscale_v1beta1_headscale.yaml
@@ -37,6 +37,5 @@ spec:
   # API Key management configuration
   api_key:
     auto_manage: true
-    manager_image: apikey-manager
     expiration: "2160h"      # 90 days (90 * 24h)
     rotation_buffer: "240h"   # 10 days (10 * 24h)


### PR DESCRIPTION
## Problem

The sample and the README Quick Start set `api_key.manager_image` to a bare image name (`apikey-manager` in the sample, `headscale-api-key` in the README). Kubernetes/containerd resolves a bare name as a Docker Hub official image (`docker.io/library/<name>:latest`), which does not exist and fails to pull:

```
failed to resolve reference "docker.io/library/headscale-api-key:latest": ... 403 Forbidden
```

Following the sample/README verbatim therefore breaks the apikey-manager sidecar out of the box.

## Fix

Remove the `manager_image` line from both the sample and the README. The field is optional and already defaults to the correct canonical reference `ghcr.io/infradohq/headscale-operator/apikey-manager:latest` via:

- the CRD default (`api/v1beta1/headscale_types.go`)
- the controller runtime fallback (`internal/controller/headscale_controller.go`)
- the image published by CI (`.github/workflows/docker.yml`)

Omitting the field lets that correct default apply, instead of overriding it with a broken value.

